### PR TITLE
Refactor navigation and add custom walker

### DIFF
--- a/public_html/wp-content/themes/kidscare-child/functions.php
+++ b/public_html/wp-content/themes/kidscare-child/functions.php
@@ -7,6 +7,14 @@ function kidscare_child_scripts() {
     wp_enqueue_style( 'parent-style', get_template_directory_uri(). '/style.css' );
 }
 
-add_filter('wp_enqueue_scripts', 'kidscare_child_scripts');
+add_filter( 'wp_enqueue_scripts', 'kidscare_child_scripts' );
 
-?>
+class Kidscare_Main_Nav_Walker extends Walker_Nav_Menu {
+    public function start_el( &$output, $item, $depth = 0, $args = array(), $id = 0 ) {
+        $item_output = '';
+        parent::start_el( $item_output, $item, $depth, $args, $id );
+        $item_output = preg_replace( '/\\s?sf-with-ul/', '', $item_output );
+        $item_output = preg_replace( '/<span[^>]*icon-ellipsis[^>]*><\\/span>/', '', $item_output );
+        $output .= $item_output;
+    }
+}

--- a/public_html/wp-content/themes/kidscare-child/style.css
+++ b/public_html/wp-content/themes/kidscare-child/style.css
@@ -16,3 +16,36 @@
 body, a, p, h1, h2, h3, h4, h5, h6 {
     color: #9e685a !important;
 }
+
+/* Main navigation */
+.main-nav {
+    display: flex;
+    gap: 1rem;
+    font-family: "Helvetica Neue", Arial, sans-serif;
+}
+.main-nav ul {
+    display: flex;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+.main-nav li {
+    position: relative;
+}
+.main-nav li ul {
+    display: none;
+    position: absolute;
+    top: 100%;
+    left: 0;
+    flex-direction: column;
+}
+.main-nav li:hover > ul {
+    display: flex;
+}
+.main-nav a {
+    padding: 0.5em 1em;
+    text-decoration: none;
+}
+.main-nav li ul li a:hover {
+    background: #f0f0f0;
+}

--- a/public_html/wp-content/themes/kidscare/templates/header-navi.php
+++ b/public_html/wp-content/themes/kidscare/templates/header-navi.php
@@ -27,27 +27,20 @@
 				</div>
 			</div><div class="sc_layouts_column sc_layouts_column_align_right sc_layouts_column_icons_position_left sc_layouts_column_fluid column-3_4">
 				<div class="sc_layouts_item">
-					<?php
-					// Main menu
-					$kidscare_menu_main = kidscare_get_nav_menu( 'menu_main' );
-					// Show any menu if no menu selected in the location 'menu_main'
-					if ( kidscare_get_theme_setting( 'autoselect_menu' ) && empty( $kidscare_menu_main ) ) {
-						$kidscare_menu_main = kidscare_get_nav_menu();
-					}
-					kidscare_show_layout(
-						$kidscare_menu_main,
-						'<nav class="menu_main_nav_area sc_layouts_menu sc_layouts_menu_default sc_layouts_hide_on_mobile"'
-							. ' itemscope itemtype="//schema.org/SiteNavigationElement"'
-							. '>',
-						'</nav>'
-					);
-					// Mobile menu button
-					?>
-					<div class="sc_layouts_iconed_text sc_layouts_menu_mobile_button">
-						<a class="sc_layouts_item_link sc_layouts_iconed_text_link" href="#">
-							<span class="sc_layouts_item_icon sc_layouts_iconed_text_icon trx_addons_icon-menu"></span>
-						</a>
-					</div>
+<?php
+// Main menu
+?>
+<nav class="main-nav" itemscope itemtype="//schema.org/SiteNavigationElement">
+<?php
+wp_nav_menu(
+array(
+'theme_location' => 'menu_main',
+'container'      => false,
+'walker'         => class_exists( 'Kidscare_Main_Nav_Walker' ) ? new Kidscare_Main_Nav_Walker() : '',
+)
+);
+?>
+</nav>
 				</div>
 				<?php
 				if ( kidscare_exists_trx_addons() ) {


### PR DESCRIPTION
## Summary
- Replace complex header menu with plain `<nav class="main-nav">`
- Add `Kidscare_Main_Nav_Walker` to strip `sf-with-ul` and ellipsis icons
- Style `.main-nav` with flexbox and submenu hover effects

## Testing
- `php -l public_html/wp-content/themes/kidscare/templates/header-navi.php`
- `php -l public_html/wp-content/themes/kidscare-child/functions.php`


------
https://chatgpt.com/codex/tasks/task_e_68a090d0c8cc8329852d126b3e6265c7