### PR TITLE
Hide mobile menu button on desktop view

### DIFF
--- a/public_html/wp-content/themes/kidscare/style.css
+++ b/public_html/wp-content/themes/kidscare/style.css
@@ -9863,4 +9863,11 @@ figcaption:has(.mfp-title:empty + .mfp-counter:empty) {
   left: -18px;
 }
 
+/* Hide mobile menu button on desktop screens */
+@media (min-width: 1024px) {
+  .sc_layouts_menu_mobile_button {
+    display: none !important;
+  }
+}
+
 /*# sourceMappingURL=style.css.map */


### PR DESCRIPTION
## Summary
- ensure mobile menu button does not appear on desktop via CSS

## Testing
- `php -l public_html/wp-content/themes/kidscare/templates/header-navi.php`
- `php -l public_html/wp-content/themes/kidscare/templates/header-mobile.php`


------
https://chatgpt.com/codex/tasks/task_e_68a0a89587cc83299f1b772e9566c357