### PR TITLE
Add desktop header with dropdown navigation and CTAs

### DIFF
--- a/public_html/wp-content/themes/kidscare-child/functions.php
+++ b/public_html/wp-content/themes/kidscare-child/functions.php
@@ -4,9 +4,11 @@
  */
 
 function kidscare_child_scripts() {
-    wp_enqueue_style( 'parent-style', get_template_directory_uri(). '/style.css' );
+    wp_enqueue_style( 'parent-style', get_template_directory_uri() . '/style.css' );
+    wp_enqueue_style( 'child-style', get_stylesheet_uri(), array( 'parent-style' ) );
+    wp_enqueue_script( 'desktop-header', get_stylesheet_directory_uri() . '/js/desktop-header.js', array(), null, true );
 }
 
-add_filter('wp_enqueue_scripts', 'kidscare_child_scripts');
+add_action( 'wp_enqueue_scripts', 'kidscare_child_scripts' );
 
 ?>

--- a/public_html/wp-content/themes/kidscare-child/js/desktop-header.js
+++ b/public_html/wp-content/themes/kidscare-child/js/desktop-header.js
@@ -1,0 +1,16 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const header = document.querySelector('.site-header');
+  if (!header) return;
+  window.addEventListener('scroll', () => {
+    header.classList.toggle('is-sticky', window.scrollY > 10);
+  });
+
+  document.querySelectorAll('.main-nav__item.has-submenu').forEach(item => {
+    const link = item.querySelector('.main-nav__link');
+    const set = v => link.setAttribute('aria-expanded', v);
+    item.addEventListener('mouseenter', () => set('true'));
+    item.addEventListener('mouseleave', () => set('false'));
+    item.addEventListener('focusin', () => set('true'));
+    item.addEventListener('focusout', () => set('false'));
+  });
+});

--- a/public_html/wp-content/themes/kidscare-child/style.css
+++ b/public_html/wp-content/themes/kidscare-child/style.css
@@ -16,3 +16,140 @@
 body, a, p, h1, h2, h3, h4, h5, h6 {
     color: #9e685a !important;
 }
+
+.site-header { display: none; }
+
+:root {
+  --pink-bg: #D9A39E;
+  --rose: #7C5652;
+  --rose-hover: #6D4A47;
+  --cta-bg: #EBC8C4;
+  --cta-bg-hover: #DFAEAA;
+  --panel-bg: #1F2427;
+  --panel-text: #FFFFFF;
+  --container: 1280px;
+  --gap-nav: 40px;
+}
+
+@media (min-width: 1024px) {
+  .site-header {
+    display: block;
+    background: var(--pink-bg);
+    color: var(--rose);
+    position: sticky;
+    top: 0;
+    z-index: 1000;
+    transition: box-shadow 0.2s, border-bottom 0.2s;
+    font-family: system-ui, -apple-system, "Segoe UI", Roboto, Inter, Arial, sans-serif;
+  }
+  .site-header.is-sticky {
+    box-shadow: 0 2px 4px rgba(124, 86, 82, 0.18);
+    border-bottom: 1px solid rgba(124, 86, 82, 0.18);
+  }
+  .site-header__inner {
+    max-width: var(--container);
+    margin: 0 auto;
+    padding: 0 32px;
+    height: 88px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+  .site-header__left,
+  .site-header__center,
+  .site-header__right {
+    display: flex;
+    align-items: center;
+  }
+  .brand img {
+    width: 64px;
+    height: 64px;
+    border-radius: 50%;
+    display: block;
+  }
+  .main-nav__list {
+    display: flex;
+    gap: var(--gap-nav);
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+  .main-nav__item {
+    position: relative;
+  }
+  .main-nav__link {
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    font-weight: 600;
+    font-size: 16px;
+    color: var(--rose);
+    text-decoration: none;
+    padding: 8px 0;
+    display: inline-block;
+  }
+  .main-nav__link:hover,
+  .main-nav__link:focus {
+    color: var(--rose-hover);
+  }
+  .main-nav__link[aria-current="page"] {
+    border-bottom: 2px solid currentColor;
+  }
+  .main-nav__link:focus-visible,
+  .submenu__link:focus-visible,
+  .btn:focus-visible {
+    outline: 2px solid #fff;
+    outline-offset: 2px;
+  }
+  .submenu {
+    display: none;
+    position: absolute;
+    top: 100%;
+    left: 0;
+    background: var(--panel-bg);
+    color: var(--panel-text);
+    padding: 20px 24px;
+    min-width: 280px;
+    border-radius: 8px;
+    box-shadow: 0 8px 16px rgba(0, 0, 0, 0.08);
+    z-index: 10;
+  }
+  .has-submenu:hover > .submenu,
+  .has-submenu:focus-within > .submenu {
+    display: block;
+  }
+  .submenu__link {
+    display: block;
+    color: var(--panel-text);
+    text-decoration: none;
+    padding: 6px 0;
+    white-space: nowrap;
+  }
+  .submenu__link:hover,
+  .submenu__link:focus {
+    text-decoration: underline;
+  }
+  .btn-group {
+    display: flex;
+    gap: 16px;
+  }
+  .btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    height: 44px;
+    padding: 0 24px;
+    border-radius: 9999px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-weight: 700;
+    text-decoration: none;
+    color: #fff;
+    background: var(--cta-bg);
+  }
+  .btn:hover {
+    background: var(--cta-bg-hover);
+  }
+  .btn:active {
+    transform: translateY(1px);
+  }
+}

--- a/public_html/wp-content/themes/kidscare-child/templates/header-default.php
+++ b/public_html/wp-content/themes/kidscare-child/templates/header-default.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Custom desktop header for child theme.
+ *
+ * @package WordPress
+ * @subpackage KIDSCARE Child
+ */
+?>
+<header class="site-header">
+  <div class="site-header__inner">
+    <div class="site-header__left">
+      <a href="<?php echo esc_url( home_url('/') ); ?>" class="brand">
+        <?php
+        if ( function_exists( 'the_custom_logo' ) && has_custom_logo() ) {
+            the_custom_logo();
+        } else {
+            echo '<span>' . esc_html( get_bloginfo( 'name' ) ) . '</span>';
+        }
+        ?>
+      </a>
+    </div>
+
+    <div class="site-header__center">
+      <nav class="main-nav" role="navigation" aria-label="Navigation principale">
+        <ul class="main-nav__list">
+          <li class="main-nav__item"><a class="main-nav__link" href="#">Accueil</a></li>
+          <li class="main-nav__item has-submenu">
+            <a class="main-nav__link" href="#" aria-haspopup="true" aria-expanded="false">Services <span aria-hidden="true">▾</span></a>
+            <ul class="submenu">
+              <li><a class="submenu__link" href="#">Accès à l’aire de jeux</a></li>
+              <li><a class="submenu__link" href="#">Fêtes d’anniversaire</a></li>
+            </ul>
+          </li>
+          <li class="main-nav__item has-submenu">
+            <a class="main-nav__link" href="#" aria-haspopup="true" aria-expanded="false">Forfaits Anniversaire <span aria-hidden="true">▾</span></a>
+            <ul class="submenu">
+              <li><a class="submenu__link" href="#">Mini-Roo Table</a></li>
+              <li><a class="submenu__link" href="#">Mini-Roo Salle Privée</a></li>
+              <li><a class="submenu__link" href="#">Jump-Roo Salle Privée</a></li>
+              <li><a class="submenu__link" href="#">Super-Roo Salle Privée</a></li>
+            </ul>
+          </li>
+          <li class="main-nav__item"><a class="main-nav__link" href="#">Contactez-nous</a></li>
+          <li class="main-nav__item"><a class="main-nav__link" href="#">Panier</a></li>
+          <li class="main-nav__item"><a class="main-nav__link" href="#">À propos</a></li>
+          <li class="main-nav__item"><a class="main-nav__link" href="#">Politique de confidentialité</a></li>
+        </ul>
+      </nav>
+    </div>
+
+    <div class="site-header__right">
+      <div class="btn-group">
+        <a href="#" class="btn btn--primary">Accès à l’aire de jeux</a>
+        <a href="#" class="btn btn--primary">Réserver salle de fête</a>
+      </div>
+    </div>
+  </div>
+</header>
+<?php
+// Keep mobile header from parent theme.
+get_template_part( apply_filters( 'kidscare_filter_get_template_part', 'templates/header-mobile' ) );
+?>


### PR DESCRIPTION
## Summary
- Implement new desktop-only header with brand logo, dropdown navigation, and dual CTA buttons.
- Add sticky behavior and accessibility attributes via vanilla JavaScript.
- Style header with pink palette variables and responsive desktop layout rules.

## Testing
- `php -l public_html/wp-content/themes/kidscare-child/functions.php`
- `php -l public_html/wp-content/themes/kidscare-child/templates/header-default.php`


------
https://chatgpt.com/codex/tasks/task_e_68a0b42308c4832999526095fc57356c